### PR TITLE
Fixed missing comma in package.json that was preventing successful build

### DIFF
--- a/AS/package.json
+++ b/AS/package.json
@@ -13,7 +13,7 @@
     "connect-ensure-login": "*",
     "cookie-parser": "~1.3.5",
     "date-arithmetic": "^3.1.0",
-    "debug": ">=2.6.9"
+    "debug": ">=2.6.9",
     "ejs": ">2.5.5",
     "express": "~4.13.1",
     "express-jwt": "^3.3.0",


### PR DESCRIPTION
The package.json file is missing a comma, hence npm install will not work as the json is malformed:

```
/ace-mqtt-mosquitto/AS$ npm install
npm ERR! file /home/bbossola/projects/rocksolid/customers/nominet/ace-mqtt-mosquitto/AS/package.json
npm ERR! code EJSONPARSE
npm ERR! JSON.parse Failed to parse json
npm ERR! JSON.parse Unexpected string in JSON at position 378 while parsing '{
npm ERR! JSON.parse   "name": "ace_authorization_server",
npm ERR! JSON.parse '
npm ERR! JSON.parse Failed to parse package.json data.
npm ERR! JSON.parse package.json must be actual JSON, not just JavaScript.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/bbossola/.npm/_logs/2019-02-06T10_39_25_086Z-debug.log
```

This change allows the project to compile correctly.